### PR TITLE
Add login/password connection for servers

### DIFF
--- a/backend/handlers/server_handlers.go
+++ b/backend/handlers/server_handlers.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
-	"os"
 	"strconv"
 
 	"ssh-gate/models"
@@ -15,16 +14,12 @@ import (
 
 // ServerHandler содержит обработчики для API серверов
 type ServerHandler struct {
-	DB      *sql.DB
-	KeyPath string // Путь к приватному ключу для подключения к серверам
+	DB *sql.DB
 }
 
 // NewServerHandler создает новый экземпляр ServerHandler
-func NewServerHandler(db *sql.DB, keyPath string) *ServerHandler {
-	return &ServerHandler{
-		DB:      db,
-		KeyPath: keyPath,
-	}
+func NewServerHandler(db *sql.DB) *ServerHandler {
+	return &ServerHandler{DB: db}
 }
 
 // CreateServer обрабатывает запрос на создание нового сервера
@@ -35,8 +30,8 @@ func (h *ServerHandler) CreateServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if server.IP == "" {
-		http.Error(w, "IP адрес обязателен", http.StatusBadRequest)
+	if server.IP == "" || server.Login == "" || server.Password == "" {
+		http.Error(w, "IP, логин и пароль обязательны", http.StatusBadRequest)
 		return
 	}
 
@@ -85,12 +80,6 @@ func (h *ServerHandler) GetAllServers(w http.ResponseWriter, r *http.Request) {
 
 // AssignServerToUser обрабатывает запрос на привязку сервера к пользователю
 func (h *ServerHandler) AssignServerToUser(w http.ResponseWriter, r *http.Request) {
-	// Читаем приватный ключ
-	keyData, err := os.ReadFile(h.KeyPath)
-	if err != nil {
-		http.Error(w, "Ошибка чтения приватного ключа: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
 
 	userIDStr := chi.URLParam(r, "userId")
 	serverIDStr := chi.URLParam(r, "serverId")
@@ -129,10 +118,10 @@ func (h *ServerHandler) AssignServerToUser(w http.ResponseWriter, r *http.Reques
 
 	// Создаем конфигурацию для SSH-подключения
 	sshConfig := ssh.SSHConfig{
-		Host:    server.IP,
-		Port:    22,       // todo надо вынести
-		User:    "deploy", //todo тут все надо выносить
-		KeyPath: string(keyData),
+		Host:     server.IP,
+		Port:     22,
+		User:     server.Login,
+		Password: server.Password,
 	}
 
 	// Добавляем публичный ключ на сервер, к которому надо получить доступ пользователю
@@ -203,19 +192,12 @@ func (h *ServerHandler) RemoveServerFromUser(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Читаем приватный ключ
-	keyData, err := os.ReadFile(h.KeyPath)
-	if err != nil {
-		http.Error(w, "Ошибка чтения приватного ключа: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	// Создаем конфигурацию для SSH-подключения
 	sshConfig := ssh.SSHConfig{
-		Host:    server.IP,
-		Port:    22, // Стандартный порт SSH
-		User:    "deploy",
-		KeyPath: string(keyData),
+		Host:     server.IP,
+		Port:     22, // Стандартный порт SSH
+		User:     server.Login,
+		Password: server.Password,
 	}
 
 	// Удаляем публичный ключ с сервера

--- a/backend/main.go
+++ b/backend/main.go
@@ -22,16 +22,9 @@ func main() {
 	}
 	defer database.Close()
 
-	// Получаем путь к приватному ключу из переменной окружения
-	os.Setenv("SSH_PRIVATE_KEY_PATH", "id_rsa_jump_server")
-	keyPath := os.Getenv("SSH_PRIVATE_KEY_PATH")
-	if keyPath == "" {
-		log.Fatal("Не указан путь к приватному ключу (SSH_PRIVATE_KEY_PATH)")
-	}
-
 	// Создаем обработчики
 	userHandler := handlers.NewUserHandler(database)
-	serverHandler := handlers.NewServerHandler(database, keyPath)
+	serverHandler := handlers.NewServerHandler(database)
 
 	// Создаем роутер
 	r := chi.NewRouter()

--- a/backend/models/server.go
+++ b/backend/models/server.go
@@ -7,18 +7,22 @@ import (
 
 // Server представляет модель сервера
 type Server struct {
-	ID int64  `json:"id"`
-	IP string `json:"ip"`
+	ID       int64  `json:"id"`
+	IP       string `json:"ip"`
+	Login    string `json:"login"`
+	Password string `json:"password"`
 }
 
 // CreateServerTable создает таблицу серверов и связующую таблицу
 func CreateServerTable(db *sql.DB) error {
 	// Создаем таблицу серверов
 	serverQuery := `
-	CREATE TABLE IF NOT EXISTS servers (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		ip TEXT NOT NULL UNIQUE
-	);
+        CREATE TABLE IF NOT EXISTS servers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ip TEXT NOT NULL UNIQUE,
+                login TEXT NOT NULL,
+                password TEXT NOT NULL
+        );
 	`
 
 	// Создаем связующую таблицу
@@ -48,11 +52,11 @@ func CreateServerTable(db *sql.DB) error {
 // AddServer добавляет новый сервер в базу данных
 func AddServer(db *sql.DB, server Server) (int64, error) {
 	query := `
-	INSERT INTO servers (ip)
-	VALUES (?);
-	`
+        INSERT INTO servers (ip, login, password)
+        VALUES (?, ?, ?);
+        `
 
-	result, err := db.Exec(query, server.IP)
+	result, err := db.Exec(query, server.IP, server.Login, server.Password)
 	if err != nil {
 		return 0, fmt.Errorf("ошибка добавления сервера: %w", err)
 	}
@@ -68,13 +72,13 @@ func AddServer(db *sql.DB, server Server) (int64, error) {
 // GetServerByID получает сервер по ID
 func GetServerByID(db *sql.DB, id int64) (Server, error) {
 	query := `
-	SELECT id, ip
-	FROM servers
-	WHERE id = ?;
-	`
+        SELECT id, ip, login, password
+        FROM servers
+        WHERE id = ?;
+        `
 
 	var server Server
-	err := db.QueryRow(query, id).Scan(&server.ID, &server.IP)
+	err := db.QueryRow(query, id).Scan(&server.ID, &server.IP, &server.Login, &server.Password)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return Server{}, fmt.Errorf("сервер с ID %d не найден", id)
@@ -88,9 +92,9 @@ func GetServerByID(db *sql.DB, id int64) (Server, error) {
 // GetAllServers получает все серверы
 func GetAllServers(db *sql.DB) ([]Server, error) {
 	query := `
-	SELECT id, ip
-	FROM servers;
-	`
+        SELECT id, ip, login, password
+        FROM servers;
+        `
 
 	rows, err := db.Query(query)
 	if err != nil {
@@ -101,7 +105,7 @@ func GetAllServers(db *sql.DB) ([]Server, error) {
 	var servers []Server
 	for rows.Next() {
 		var server Server
-		if err := rows.Scan(&server.ID, &server.IP); err != nil {
+		if err := rows.Scan(&server.ID, &server.IP, &server.Login, &server.Password); err != nil {
 			return nil, fmt.Errorf("ошибка чтения данных сервера: %w", err)
 		}
 		servers = append(servers, server)
@@ -132,7 +136,7 @@ func AssignServerToUser(db *sql.DB, userID, serverID int64) error {
 // GetUserServers получает все серверы пользователя
 func GetUserServers(db *sql.DB, userID int64) ([]Server, error) {
 	query := `
-	SELECT s.id, s.ip
+        SELECT s.id, s.ip, s.login, s.password
 	FROM servers s
 	JOIN user_servers us ON s.id = us.server_id
 	WHERE us.user_id = ?;
@@ -147,7 +151,7 @@ func GetUserServers(db *sql.DB, userID int64) ([]Server, error) {
 	var servers []Server
 	for rows.Next() {
 		var server Server
-		if err := rows.Scan(&server.ID, &server.IP); err != nil {
+		if err := rows.Scan(&server.ID, &server.IP, &server.Login, &server.Password); err != nil {
 			return nil, fmt.Errorf("ошибка чтения данных сервера: %w", err)
 		}
 		servers = append(servers, server)

--- a/frontend/src/modules/servers/pages/PServers.vue
+++ b/frontend/src/modules/servers/pages/PServers.vue
@@ -45,6 +45,26 @@
                 required
               />
             </div>
+            <div class="form-group">
+              <label class="form-label" for="login">Логин</label>
+              <input
+                type="text"
+                id="login"
+                v-model="newServer.login"
+                class="form-input"
+                required
+              />
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="password">Пароль</label>
+              <input
+                type="password"
+                id="password"
+                v-model="newServer.password"
+                class="form-input"
+                required
+              />
+            </div>
             <div class="modal-footer">
               <button type="button" class="button" @click="showAddServerModal = false">
                 Отмена
@@ -68,11 +88,15 @@ import { serversFetch, serverCreate, serverDelete } from '../api'
 interface Server {
   id: number
   ip: string
+  login: string
+  password: string
 }
 
 const showAddServerModal = ref(false)
 const newServer = ref({
-  ip: ''
+  ip: '',
+  login: '',
+  password: ''
 })
 
 const { data: servers } = useQuery({


### PR DESCRIPTION
## Summary
- extend server model with login/password
- update database schema and queries
- enable SSH connection via password
- store login/password from frontend when creating servers

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684436f67264832bbf486b4e0ae812c8