### PR TITLE
Add ssh port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ POST /api/servers
 Content-Type: application/json
 
 {
-    "ip": "192.168.1.100"
+    "ip": "192.168.1.100",
+    "port": 2222
 }
 ```
 

--- a/backend/handlers/server_handlers.go
+++ b/backend/handlers/server_handlers.go
@@ -40,6 +40,10 @@ func (h *ServerHandler) CreateServer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if server.Port == 0 {
+		server.Port = 22
+	}
+
 	id, err := models.AddServer(h.DB, server)
 	if err != nil {
 		http.Error(w, "Ошибка при добавлении сервера: "+err.Error(), http.StatusInternalServerError)
@@ -130,7 +134,7 @@ func (h *ServerHandler) AssignServerToUser(w http.ResponseWriter, r *http.Reques
 	// Создаем конфигурацию для SSH-подключения
 	sshConfig := ssh.SSHConfig{
 		Host:    server.IP,
-		Port:    22,       // todo надо вынести
+		Port:    server.Port,
 		User:    "deploy", //todo тут все надо выносить
 		KeyPath: string(keyData),
 	}
@@ -213,7 +217,7 @@ func (h *ServerHandler) RemoveServerFromUser(w http.ResponseWriter, r *http.Requ
 	// Создаем конфигурацию для SSH-подключения
 	sshConfig := ssh.SSHConfig{
 		Host:    server.IP,
-		Port:    22, // Стандартный порт SSH
+		Port:    server.Port,
 		User:    "deploy",
 		KeyPath: string(keyData),
 	}

--- a/backend/models/server.go
+++ b/backend/models/server.go
@@ -7,18 +7,20 @@ import (
 
 // Server представляет модель сервера
 type Server struct {
-	ID int64  `json:"id"`
-	IP string `json:"ip"`
+	ID   int64  `json:"id"`
+	IP   string `json:"ip"`
+	Port int    `json:"port"`
 }
 
 // CreateServerTable создает таблицу серверов и связующую таблицу
 func CreateServerTable(db *sql.DB) error {
 	// Создаем таблицу серверов
 	serverQuery := `
-	CREATE TABLE IF NOT EXISTS servers (
-		id INTEGER PRIMARY KEY AUTOINCREMENT,
-		ip TEXT NOT NULL UNIQUE
-	);
+        CREATE TABLE IF NOT EXISTS servers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ip TEXT NOT NULL UNIQUE,
+                port INTEGER NOT NULL DEFAULT 22
+        );
 	`
 
 	// Создаем связующую таблицу
@@ -48,11 +50,11 @@ func CreateServerTable(db *sql.DB) error {
 // AddServer добавляет новый сервер в базу данных
 func AddServer(db *sql.DB, server Server) (int64, error) {
 	query := `
-	INSERT INTO servers (ip)
-	VALUES (?);
-	`
+        INSERT INTO servers (ip, port)
+        VALUES (?, ?);
+        `
 
-	result, err := db.Exec(query, server.IP)
+	result, err := db.Exec(query, server.IP, server.Port)
 	if err != nil {
 		return 0, fmt.Errorf("ошибка добавления сервера: %w", err)
 	}
@@ -68,13 +70,13 @@ func AddServer(db *sql.DB, server Server) (int64, error) {
 // GetServerByID получает сервер по ID
 func GetServerByID(db *sql.DB, id int64) (Server, error) {
 	query := `
-	SELECT id, ip
+        SELECT id, ip, port
 	FROM servers
 	WHERE id = ?;
 	`
 
 	var server Server
-	err := db.QueryRow(query, id).Scan(&server.ID, &server.IP)
+	err := db.QueryRow(query, id).Scan(&server.ID, &server.IP, &server.Port)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return Server{}, fmt.Errorf("сервер с ID %d не найден", id)
@@ -88,7 +90,7 @@ func GetServerByID(db *sql.DB, id int64) (Server, error) {
 // GetAllServers получает все серверы
 func GetAllServers(db *sql.DB) ([]Server, error) {
 	query := `
-	SELECT id, ip
+        SELECT id, ip, port
 	FROM servers;
 	`
 
@@ -101,7 +103,7 @@ func GetAllServers(db *sql.DB) ([]Server, error) {
 	var servers []Server
 	for rows.Next() {
 		var server Server
-		if err := rows.Scan(&server.ID, &server.IP); err != nil {
+		if err := rows.Scan(&server.ID, &server.IP, &server.Port); err != nil {
 			return nil, fmt.Errorf("ошибка чтения данных сервера: %w", err)
 		}
 		servers = append(servers, server)
@@ -132,7 +134,7 @@ func AssignServerToUser(db *sql.DB, userID, serverID int64) error {
 // GetUserServers получает все серверы пользователя
 func GetUserServers(db *sql.DB, userID int64) ([]Server, error) {
 	query := `
-	SELECT s.id, s.ip
+        SELECT s.id, s.ip, s.port
 	FROM servers s
 	JOIN user_servers us ON s.id = us.server_id
 	WHERE us.user_id = ?;
@@ -147,7 +149,7 @@ func GetUserServers(db *sql.DB, userID int64) ([]Server, error) {
 	var servers []Server
 	for rows.Next() {
 		var server Server
-		if err := rows.Scan(&server.ID, &server.IP); err != nil {
+		if err := rows.Scan(&server.ID, &server.IP, &server.Port); err != nil {
 			return nil, fmt.Errorf("ошибка чтения данных сервера: %w", err)
 		}
 		servers = append(servers, server)

--- a/frontend/src/modules/servers/pages/PServers.vue
+++ b/frontend/src/modules/servers/pages/PServers.vue
@@ -12,7 +12,7 @@
       <div v-for="server in servers" :key="server.id" class="list-item">
         <div class="list-item-content">
           <div>
-            <h3>IP: {{ server.ip }}</h3>
+            <h3>{{ server.ip }}:{{ server.port }}</h3>
           </div>
           <div class="list-item-actions">
             <button class="button" @click="viewServerUsers(server)">
@@ -45,6 +45,17 @@
                 required
               />
             </div>
+            <div class="form-group">
+              <label class="form-label" for="port">Порт</label>
+              <input
+                type="number"
+                id="port"
+                v-model.number="newServer.port"
+                class="form-input"
+                min="1"
+                max="65535"
+              />
+            </div>
             <div class="modal-footer">
               <button type="button" class="button" @click="showAddServerModal = false">
                 Отмена
@@ -68,11 +79,13 @@ import { serversFetch, serverCreate, serverDelete } from '../api'
 interface Server {
   id: number
   ip: string
+  port: number
 }
 
 const showAddServerModal = ref(false)
 const newServer = ref({
-  ip: ''
+  ip: '',
+  port: 22
 })
 
 const { data: servers } = useQuery({

--- a/frontend/src/modules/user-servers/pages/PUsersSeversAccess.vue
+++ b/frontend/src/modules/user-servers/pages/PUsersSeversAccess.vue
@@ -14,7 +14,7 @@
               <h4>Доступные серверы:</h4>
               <ul>
                 <li v-for="server in userServers[user.id]" :key="server.id" class="server-item">
-                  <span>{{ server.ip }}</span>
+                  <span>{{ server.ip }}:{{ server.port }}</span>
                   <button class="button button-danger" @click="onRemoveServerFromUser(user.id, server.id)">
                     Удалить доступ
                   </button>
@@ -48,7 +48,7 @@
               >
                 <option value="">Выберите сервер</option>
                 <option v-for="server in availableServers" :key="server.id" :value="server.id">
-                  {{ server.ip }}
+                  {{ server.ip }}:{{ server.port }}
                 </option>
               </select>
             </div>
@@ -81,6 +81,7 @@ interface User {
 interface Server {
   id: number
   ip: string
+  port: number
 }
 
 const showAssignServerModal = ref(false)


### PR DESCRIPTION
## Summary
- allow specifying port when creating servers
- store port in DB and return it in API responses
- use server port in ssh configs
- display port in server lists and selection
- document new request format in README

## Testing
- `go vet ./...` *(fails: Forbidden download)*
- `npm run lint` *(fails: jiti missing)*

------
https://chatgpt.com/codex/tasks/task_e_684439e39ad8832b923e7d5a2c1b5213