### PR TITLE
Add edit modals

### DIFF
--- a/frontend/src/modules/servers/api/index.ts
+++ b/frontend/src/modules/servers/api/index.ts
@@ -23,3 +23,14 @@ export const serverDelete = async (id: number) => {
   })
   return true;
 }
+
+export const serverUpdate = async (id: number, server: any) => {
+  const response = await fetchApi(`/api/servers/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(server)
+  })
+  return await response.json()
+}

--- a/frontend/src/modules/users/api/index.ts
+++ b/frontend/src/modules/users/api/index.ts
@@ -23,3 +23,14 @@ export const userDelete = async (id: number) => {
   return true;
 }
 
+export const userUpdate = async (id: number, user: any) => {
+  const response = await fetchApi(`/api/users/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(user)
+  })
+  return await response.json()
+}
+


### PR DESCRIPTION
## Summary
- implement user edit API and modal
- implement server edit API and modal

## Testing
- `npm run lint` *(fails: jiti library is required)*

------
https://chatgpt.com/codex/tasks/task_e_6844687081a4832b83099712bfe39021