### PR TITLE
Remove unused jump key references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
 # Копируем собранный бэкэнд
 COPY --from=backend-builder /app/backend/main ./backend/main
 COPY --from=backend-builder /app/backend/authorized_keys ./backend/authorized_keys
-COPY --from=backend-builder /app/backend/id_rsa_jump_server ./backend/id_rsa_jump_server
 
 # Указываем порт
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ go run main.go
 
 Приложение будет доступно по адресу `http://localhost:8080` и будет обслуживать статические файлы из `frontend/dist`.
 
+## Запуск в Docker
+
+Готовый образ приложения доступен на Docker Hub. Его можно использовать, если не хочется собирать фронтенд и бэкенд вручную.
+
+```bash
+# загрузить последнюю версию образа
+docker pull foxisfox/ssh-gate:latest
+
+# запустить контейнер
+docker run -p 8080:8080 \
+  -v $PWD/users.db:/app/backend/users.db \
+  -v $PWD/authorized_keys:/app/backend/authorized_keys \
+  foxisfox/ssh-gate:latest
+```
+
+После запуска приложение будет доступно по адресу `http://localhost:8080`. База данных и файл `authorized_keys` будут сохранены на хосте.
+
 ## API
 
 ### Пользователи


### PR DESCRIPTION
## Summary
- update Docker instructions without the unused jump key
- remove the jump key copy step from the Dockerfile

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `cd backend && go test ./...` *(fails: unable to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684498dcdb90832ba07c0755f7bcbd08